### PR TITLE
fix(remote): use asset name over filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,10 @@ function getFederationStats(stats, federationPlugin) {
   return {
     remote,
     entry: `${stats.publicPath !== "auto" ? stats.publicPath || "" : ""}${
-      federationPlugin._options.filename
+      stats.assetsByChunkName[remote] &&
+      stats.assetsByChunkName[remote].length === 1
+        ? stats.assetsByChunkName[remote][0]
+        : federationPlugin._options.filename
     }`,
     sharedModules,
     exposes,


### PR DESCRIPTION
Hello, I use your plugin and I have a use case where the entry file name contains `[contenthash]` so I created this PR to handle it by retrieving the chunk name in `assetsByChunkName`.