### PR TITLE
version 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-federated-stats-plugin",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Write out relevant federation stats to a file for further consumption.",
   "main": "index.js",
   "homepage": "https://github.com/jacob-ebey/webpack-federated-stats-plugin#readme",


### PR DESCRIPTION
Hello @jacob-ebey , my last PR was merged and you released a new version but it seems that the release version was already [used](https://www.npmjs.com/package/webpack-federated-stats-plugin/v/2.0.8).
So here is a PR which only bumps the package version to be able to use the last changes.
